### PR TITLE
Removing default `iterationCount`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,6 @@ inputs:
   iterationCount:
     description: 'Number of iterations to run on the collection'
     required: false
-    default: '1'
   iterationData:
     description: 'Path to CSV or JSON data file'
     required: false


### PR DESCRIPTION
Could I suggest that the default of `1` for the default `iterationCount` is removed?

Passing no iteration count to the newman CLI it runs all iterations. This is our desired behaviour for our use case.

Many thanks!